### PR TITLE
Update 5_diagnostics_plot.R Line 110 Names of prop Variable

### DIFF
--- a/scripts/data_processing/5_diagnostics_plots.R
+++ b/scripts/data_processing/5_diagnostics_plots.R
@@ -107,7 +107,7 @@ prop <- wq.temp %>%
   summarise_at(vars(loadvars), sum)
 
 # change names to be shortened/clean versions
-names(prop)[2:ncol(prop)] <- clean_names[(length(concvars) + 1):(length(clean_names))]
+names(prop)[2:ncol(prop)] <- clean_names
 prop.long <- prop %>%
   gather(variable, value, -frozen)
 


### PR DESCRIPTION
prop sum of loads had unclean names. In line 110 you wanted to change these names using the clean_names variable. The indexing in line 110 seems to be taking the length of convars to length of cleannames, this only displays 1 name. I'm not sure what the purpose of this index was. Eliminating the indexing and using just the clean_names variable seems to work.