### PR TITLE
Jan 2020 update

### DIFF
--- a/scripts/data_analysis/0_before_after_datmod_prep.R
+++ b/scripts/data_analysis/0_before_after_datmod_prep.R
@@ -24,5 +24,8 @@ predictors.keep <- c(names.cor[-drop.predictors], 'frozen')
 dat.mod[,responses] <- log10(dat.mod[,responses])
 sums <- colSums(dat.mod[,responses])
 if(any(is.infinite(sums))) {
-  stop('Zeros in the response variables caused values to be infinite when log transformed. Please see code in scripts/data_analysis/1_mdc_before_after.R to debug.', call. = F)
+  stop('Zeros in the response variables caused values to be infinite when log transformed. Please see code in scripts/data_analysis/0_before_after_datmod_prep.R to debug.', call. = F)
 }
+
+# for now, drop Inf values created by logging - TO DO THIS COMMENT OUT LINES 26, 27 AND UNCOMMENT THE FOLLOWING
+#dat.mod <- dat.mod[!is.infinite(rowSums(dat.mod[,responses])),]

--- a/scripts/data_analysis/1_mdc_before_after.R
+++ b/scripts/data_analysis/1_mdc_before_after.R
@@ -49,3 +49,5 @@ if (nrow(mdc) == length(responses)) {
 } else {
   stop("Somethign went wrong with calculating the minimum detectable change. To debug, see code in scripts/data_analysis/1_mdc_before_after.R.")
 }
+
+

--- a/scripts/data_analysis/1_mdc_paired.R
+++ b/scripts/data_analysis/1_mdc_paired.R
@@ -33,15 +33,15 @@ if (length(concentrations) == 1 & !is.na(concentrations)){
   con_concvars <- grep(control_ste, concvars, ignore.case = TRUE, value = TRUE)
 }
 
-if (length(other_responses) == 1 & !is.na(other_responses)){
-  othervars <- grep(concentrations, names(wq), ignore.case = TRUE, value = TRUE)
+if (length(other_responses) >= 1 & !is.na(other_responses)){
+  othervars <- grep("peak_discharge|runoff_volume", names(wq), ignore.case = TRUE, value = TRUE)
   trt_othervars <- grep(test_site, othervars, ignore.case = TRUE, value = TRUE)
   con_othervars <- grep(control_site, othervars, ignore.case = TRUE, value = TRUE)
-} else if (is.na(concentrations)) {
+} else if (is.na(other_responses)) {
   trt_othervars <- NA
   con_othervars <- NA
 } else {
-  othervars <- concentrations
+  othervars <- other_responses
   trt_othervars <- grep(test_site, othervars, ignore.case = TRUE, value = TRUE)
   con_othervars <- grep(control_site, othervars, ignore.case = TRUE, value = TRUE)
 }

--- a/scripts/data_analysis/2_paired_mods_before_only.R
+++ b/scripts/data_analysis/2_paired_mods_before_only.R
@@ -1,5 +1,5 @@
 # loop through each response var
-# uses vars set up in 1_mds_paired.R
+# uses vars set up in 1_mdc_paired.R
 dat <- wq
 out <- data.frame(matrix(nrow = length(trt_vars), ncol = 10))
 names(out) <- c('response', 'rsq', 'pval_period_int', 'pval_period_slope', 'intercept', 'slope', 

--- a/scripts/data_processing/1_calc_storm_wq_paired.R
+++ b/scripts/data_processing/1_calc_storm_wq_paired.R
@@ -67,8 +67,9 @@ trt_combined_events <- name_changer(trt_combined_events, 'trt_')
 
 wq <- full_join(con_combined_events, trt_combined_events, by = 'unique_storm_number')
 
-# remove rows with NA that occur due to unmatched pairs (event at one site did not occur at other)
-wq <- wq[complete.cases(wq), ]
+# remove rows with NA or 0 loads that occur due to unmatched pairs (event at one site did not occur at other)
+#wq<- wq[wq==0] <- NA
+wq <- wq[complete.cases(wq), ]																										  
 
 # set dates to time zone
 .origin <- as.POSIXct(ifelse(Sys.info()[['sysname']] == "Windows", "1899-12-30", "1904-01-01"))

--- a/scripts/data_processing/2_calc_discharge_variables.R
+++ b/scripts/data_processing/2_calc_discharge_variables.R
@@ -26,7 +26,7 @@ if (is.na(discharge_file)) {
 
 stats = c('sum')
 
-discharge_vars <- TSstats(discharge.dat, date = 'Date', varnames = 'Flow_Inst', dates = storms, starttime = "storm_start",
+discharge_vars <- TSstats(discharge.dat, date = 'dateTime', varnames = 'Flow_Inst', dates = storms, starttime = "storm_start",
                           times = antecedent_days, units = 'days', stats.return = stats)
 
 # rename columns
@@ -37,7 +37,7 @@ discharge_vars <- select(discharge_vars, -storm_start)
 temp_filename <- file.path('data_cached', paste0(site, '_discharge_variables.csv'))
 write.csv(discharge_vars, temp_filename, row.names = FALSE)
 
-test <- discharge_vars[!is.na(discharge_vars$ant_dis_1day_max), ]
+test <- discharge_vars[!is.na(discharge_vars$ant_dis_1day_sum), ]
 
 if (nrow(test) > 0) {
   message(paste("The discharge data have been processed. Please check", temp_filename, "to ensure correct processing."))

--- a/scripts/data_processing/2_calc_rain_variables.R
+++ b/scripts/data_processing/2_calc_rain_variables.R
@@ -46,7 +46,7 @@ if (is.na(rain_file)) {
     
   # read in precip file
   precip_raw <- read.csv(file.path('data_raw', rain_file), stringsAsFactors = FALSE, strip.white = TRUE)
-  precip_raw[,'pdate'] <- as.POSIXct(precip_raw[,'pdate'], tz = site_tz)
+  precip_raw[,'pdate'] <- as.POSIXct(precip_raw[,'pdate'], tz = site_tz, format = datetime_format)
   
   #names(precip_raw) <- c('pdate', 'rain')
 }

--- a/scripts/data_processing/2_calc_weather_variables.R
+++ b/scripts/data_processing/2_calc_weather_variables.R
@@ -86,7 +86,7 @@ for (i in 1:nrow(storms)) {
   
 }
 
-weather.dat <- select(storms, unique_storm_number, sin_sdate:snwd_diff)
+weather.dat <- select(storms, unique_storm_number, sin_sdate:ncol(storms))
 weather.dat[c("snwd_diff")][is.na(weather.dat[c("snwd_diff")])] <- 0
 weather_tempname <- file.path('data_cached', paste0(site, '_weather_by_storm.csv'))
 write.csv(weather.dat, weather_tempname, row.names = F)

--- a/scripts/data_processing/2_calc_weather_variables.R
+++ b/scripts/data_processing/2_calc_weather_variables.R
@@ -30,18 +30,19 @@ if (!is.na(weather_file)) {
 
 # calculate change in snow depth
 # check if snow var is in weather_dat
+# if (!is.na(weather_file) & 'snwd' %in% names(weather_dat)) {
 if (!is.na(weather_file) & 'snwd' %in% names(weather_file)) {
   snow_in_file <- TRUE
 } else {
   snow_in_file <- FALSE
 }
 
-if (snow_in_file == FALSE) {
-  snowpack_diff <- diff(weather_noaa$snwd)
-  weather_noaa$snwd_diff[2:nrow(weather_noaa)] <- snowpack_diff
-} else {
+if (snow_in_file == TRUE) {
   snowpack_diff <- diff(weather_dat$snwd)
   weather_dat$snwd_diff[2:nrow(weather_dat)] <- snowpack_diff
+} else {
+  snowpack_diff <- diff(weather_noaa$snwd)
+  weather_noaa$snwd_diff[2:nrow(weather_noaa)] <- snowpack_diff
 }
 
 if (!is.na(weather_file) & !is.na(noaa_site)) {
@@ -86,7 +87,7 @@ for (i in 1:nrow(storms)) {
 }
 
 weather.dat <- select(storms, unique_storm_number, sin_sdate:snwd_diff)
-
+weather.dat[c("snwd_diff")][is.na(weather.dat[c("snwd_diff")])] <- 0
 weather_tempname <- file.path('data_cached', paste0(site, '_weather_by_storm.csv'))
 write.csv(weather.dat, weather_tempname, row.names = F)
 

--- a/scripts/data_processing/5_paired_diagnostics_plots.R
+++ b/scripts/data_processing/5_paired_diagnostics_plots.R
@@ -1,6 +1,6 @@
 # diagnostic plots for paired design
 test_site <- 'trt'
-control_site <- 'con' 
+control_site <- 'con'
 
 tempfile <- file.path('data_cached', paste0(site, '_', site_paired, "_prepped_WQbystorm.csv"))
 wq <- read.csv(tempfile, stringsAsFactors = F)

--- a/scripts/functions/fxns_data_processing.R
+++ b/scripts/functions/fxns_data_processing.R
@@ -95,8 +95,8 @@ combine_sub_events <- function(wq, concvars, loadvars, flagvars) {
     stormdesc <- storms %>%
       group_by(unique_storm_number) %>%
       summarise(
-        sample_start = min(sample_start, na.rm = TRUE),
-        sample_end = max(sample_end, na.rm = TRUE),
+        #sample_start = min(sample_start, na.rm = TRUE),
+        #sample_end = max(sample_end, na.rm = TRUE),
         storm_start = min(storm_start),
         storm_end = max(storm_end),
         peak_discharge = max(peak_discharge), 
@@ -120,8 +120,8 @@ combine_sub_events <- function(wq, concvars, loadvars, flagvars) {
     stormdesc <- storms %>%
       group_by(unique_storm_number) %>%
       summarise(
-        sample_start = min(sample_start, na.rm = TRUE),
-        sample_end = max(sample_end, na.rm = TRUE),
+        #sample_start = min(sample_start, na.rm = TRUE),
+        #sample_end = max(sample_end, na.rm = TRUE),
         storm_start = min(storm_start),
         storm_end = max(storm_end),
         peak_discharge = max(peak_discharge), 

--- a/scripts/master_run_file.R
+++ b/scripts/master_run_file.R
@@ -20,6 +20,8 @@ library(ggplot2)
 library(pdp)
 library(jtools)
 library(caret)
+library(tidyr)
+library(interactions)					 
 
 # if you do not have certain libraries installed (e.g., the code above failes for one or 
 # more packages) you need to install them (one time only). To do so, uncomment the lines below

--- a/scripts/run_files/analysis_run_file.R
+++ b/scripts/run_files/analysis_run_file.R
@@ -21,7 +21,13 @@ if (study_type == 'before_after') {
   mod_env <- new.env()
   source('scripts/data_analysis/1_mdc_paired.R', echo = F, local = mod_env)
   
+  if (bmp_date>end_date) {
+    message('Plotting paired watershed vs control watershed before-only-data')
+    source('scripts/data_analysis/2_paired_mods_before_only.R', echo = F, local = mod_env)
+    
+  }else{
   message('Testing whether BMP implementation reduced loads/concentrations.')
   source('scripts/data_analysis/2_paired_mods.R', echo = F, local = mod_env)
   
+  }
 }

--- a/scripts/run_files/processing_run_file.R
+++ b/scripts/run_files/processing_run_file.R
@@ -10,12 +10,11 @@ source('scripts/data_processing/0_check_inputs.R')
 source('scripts/functions/fxns_data_processing.R')
 
 if (study_type == 'before_after') {
+
 # source the water quality file which is the basis for all other processing.
 message('Importing and processing the storm water quality data for the before & after study.')
 wq_env <- new.env()
 source('scripts/data_processing/1_calc_storm_wq.R', echo = F, local = wq_env)
-
-
 
 # source all data processing steps
 message('Importing and processing rain metrics.')


### PR DESCRIPTION
In addition to some minor fixes (spelling, spacing, descriptions, naming), this update adds a few commented lines that were specific to a site, and can be uncommented if needed in future runs. 

Additional changes:

1_calc_storm_wq:
- changes "runoff_volume" to "storm_runoff_cubic_feet" to be consistent with how data are submitted
- removes "sample_start" and "sample_end" from steps that weren't supposed to be using them, and use storm_start and end instead
- adds a few filters to toggle on/off depending on specifics for a run

2_calc_weather_variables:
- when script includes "other responses" like soil probe data, the weather.dat df cut off these extra variables. Fixed to select to the last column no matter its number or name by using ncol.
- changed approach to if, then statement for snowpack calculation
- had problems with WEQ calc if snwd_diff had NAs, added line to change snwdiff NA's to 0s

Paired analysis scripts:
made sure lines to handle separate treatment and control data tables were present
added "other responses" to MDC_paired analysis
added script for "before only" paired watershed data sets
 
